### PR TITLE
Bugfix rendering RSS feed items

### DIFF
--- a/includes/jquery.ticker.js
+++ b/includes/jquery.ticker.js
@@ -221,10 +221,13 @@
 												else if (xmlItems.childNodes[y].nodeName == 'link') {												    
 													link = xmlItems.childNodes[y].lastChild.nodeValue; 
 												}
-												if ((title !== false && title != '') && link !== false) {
-												    settings.newsArr['item-' + count] = { type: opts.titleText, content: '<a href="' + link + '">' + title + '</a>' };												    count++;												    title = false;												    link = false;
-												}
 											}	
+											if ((title !== false && title != '') && link !== false) {
+												settings.newsArr['item-' + count] = { type: opts.titleText, content: '<a href="' + link + '">' + title + '</a>' };
+												count++;
+												title = false;
+												link = false;
+											}
 										}		
 									}			
 									// quick check here to see if we actually have any content - log error if not


### PR DESCRIPTION
If the link-node is set before the title-node in the rss-feed, your script will output an "undefined"-title for the first item and every item title is shifted for the next entries.
I simply moved the condition out of the node-loop to fix this issue.
