### PR TITLE
Changed deprecated live() function to on() to support latest JQuery builds

### DIFF
--- a/includes/jquery.ticker.js
+++ b/includes/jquery.ticker.js
@@ -118,7 +118,7 @@
 				// add the controls to the DOM if required
 				if (opts.controls) {
 					// add related events - set functions to run on given event
-					$(settings.dom.controlsID).live('click mouseover mousedown mouseout mouseup', function (e) {
+					$(settings.dom.controlsID).on('click mouseover mousedown mouseout mouseup', null, function (e) {
 						var button = e.target.id;
 						if (e.type == 'click') {	
 							switch (button) {


### PR DESCRIPTION
`live()` function is deprecated in latest JQuery versions. It is replaced with `on` function. 
